### PR TITLE
WAZO-1424 fix our self generate certificate to works with chrome on macos

### DIFF
--- a/debian/xivo-certs.postinst
+++ b/debian/xivo-certs.postinst
@@ -10,10 +10,10 @@ case "$1" in
         # generate X.509 certificates if necessary. Valid for 10 years.
         config=/usr/share/xivo-certs/openssl-x509.conf
         if [ ! -e "$new_key" -o ! -e "$new_cert" ] ; then
-            openssl req -x509 -sha256 -nodes -days 3650 -newkey rsa:2048 -config "$config" -keyout "$new_key" -out "$new_cert"
+            openssl req -x509 -sha256 -nodes -days 865 -newkey rsa:2048 -config "$config" -keyout "$new_key" -out "$new_cert"
         elif /usr/share/xivo-certs/bin/certificate-needs-subjectaltname "${new_cert}" ; then
             # regenerate with subjectAltName
-            openssl req -x509 -sha256 -days 3650 -new -config "${config}" -key "${new_key}" -out "${new_cert}"
+            openssl req -x509 -sha256 -days 865 -new -config "${config}" -key "${new_key}" -out "${new_cert}"
         fi
 
         # ensure ownership and permissions

--- a/openssl-x509.conf
+++ b/openssl-x509.conf
@@ -4,10 +4,11 @@ distinguished_name = req_distinguished_name
 x509_extensions = v3_ca
 
 [req_distinguished_name]
-CN = *
+CN = localhost
 
 [v3_ca]
 subjectAltName = @alternate_names
+extendedKeyUsage = serverAuth
 
 [alternate_names]
 DNS.1 = localhost


### PR DESCRIPTION
first fix is the duration of the certificat, we need to have max 865 days, second fix is we need to define EKU to serverAuth.