### PR TITLE
fix wazo-certs renaming executiong order

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,9 @@ Standards-Version: 3.9.6
 
 Package: wazo-certs
 Architecture: all
+# Pre-Depends nginx is only a workaround to fix migration xivo-certs/wazo-certs
+# Remove after Bookworm migration
+Pre-Depends: nginx
 Depends:
  ${misc:Depends},
  openssl,


### PR DESCRIPTION
Dependencies are:
wazo-nginx: pre-depends on nginx and depends on wazo-certs
wazo-certs does not depend on nginx

When upgrading (from buster to bullseye), wazo-certs is installed (and
xivo-certs removed), then nginx is updated. But when nginx is updated,
postinst from package will try to restart nginx and will fail because
wazo-certs still contains old config to xivo-certs

Adding Pre-Depends make nginx to be updated before removing xivo-certs
config